### PR TITLE
UnboundLocalError: local variable 'val_acc' referenced before assignment

### DIFF
--- a/pytorch_toolkit/action_recognition/action_recognition/train.py
+++ b/pytorch_toolkit/action_recognition/action_recognition/train.py
@@ -61,7 +61,7 @@ def train(args, model, train_loader, val_loader, criterion, optimizer, scheduler
                 val_acc = validate(args, epoch, val_loader, model, criterion, logger)
                 logger.log_value("val/generalization_error", val_acc - train_acc)
 
-        if isinstance(scheduler, lr_scheduler.ReduceLROnPlateau):
+        if isinstance(scheduler, lr_scheduler.ReduceLROnPlateau) and epoch >= args.validate:
             scheduler.step(val_acc)
         else:
             scheduler.step()


### PR DESCRIPTION
by default args.validate is 5, so on first epoch it gives following error:
"UnboundLocalError: local variable 'val_acc' referenced before assignment"

There are two ways this can be avoided:
1) Validate on each epoch.
2) add above check