### PR TITLE
Add base val_acc  in train.py

### DIFF
--- a/pytorch_toolkit/action_recognition/action_recognition/train.py
+++ b/pytorch_toolkit/action_recognition/action_recognition/train.py
@@ -43,6 +43,7 @@ def train_epoch(args, epoch, data_loader, model, criterion, optimizer, logger):
 
 
 def train(args, model, train_loader, val_loader, criterion, optimizer, scheduler, logger):
+    val_acc = 0.0
     for epoch in range(args.begin_epoch, args.n_epochs + 1):
         with logger.scope(epoch):
             for i, group in enumerate(optimizer.param_groups):


### PR DESCRIPTION
by default args.validate is 5, so on first epoch it gives following error:
"UnboundLocalError: local variable 'val_acc' referenced before assignment"

There are two ways this can be avoided:

Validate on each epoch.
Initialize val_acc before staring to some value ex. 0