### PR TITLE
refactored tests

### DIFF
--- a/pytorch_toolkit/object_detection/init_venv.sh
+++ b/pytorch_toolkit/object_detection/init_venv.sh
@@ -44,6 +44,9 @@ pip install -e ../../external/mmdetection/
 MMDETECTION_DIR=`realpath ../../external/mmdetection/`
 echo "export MMDETECTION_DIR=${MMDETECTION_DIR}" >> ${venv_dir}/bin/activate
 
+# install ote
+pip install -e ../../pytorch_toolkit/ote/
+
 deactivate
 
 echo

--- a/pytorch_toolkit/object_detection/tests/common/test_case.py
+++ b/pytorch_toolkit/object_detection/tests/common/test_case.py
@@ -22,7 +22,7 @@ import torch
 import yaml
 
 from common.utils import collect_ap, run_through_shell
-from ote.misc import get_file_size_and_sha256, download_snapshot_if_not_yet
+from ote.misc import download_snapshot_if_not_yet
 
 
 def get_dependencies(template_file):

--- a/pytorch_toolkit/object_detection/tests/common/test_case.py
+++ b/pytorch_toolkit/object_detection/tests/common/test_case.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import logging
 import json
 import os
+from subprocess import run
 import unittest
 
 import torch
 import yaml
 
 from common.utils import collect_ap, run_through_shell
+from ote.misc import get_file_size_and_sha256, download_snapshot_if_not_yet
 
 
 def get_dependencies(template_file):
@@ -50,6 +53,8 @@ def create_test_case(problem_name, model_name, ann_file, img_root):
             cls.dependencies = get_dependencies(cls.template_file)
             cls.epochs_delta = 2
             cls.total_epochs = get_epochs(cls.template_file) + cls.epochs_delta
+
+            download_snapshot_if_not_yet(cls.template_file, cls.template_folder)
 
             run_through_shell(
                 f'cd {cls.template_folder};'
@@ -162,6 +167,8 @@ def create_export_test_case(problem_name, model_name, ann_file, img_root, alt_ss
             cls.img_root = img_root
             cls.dependencies = get_dependencies(cls.template_file)
             cls.test_export_thr = 0.031
+
+            download_snapshot_if_not_yet(cls.template_file, cls.template_folder)
 
         def skip_if_cpu_is_not_supported(self):
             with open(self.template_file) as read_file:

--- a/pytorch_toolkit/object_detection/tests/common/test_case.py
+++ b/pytorch_toolkit/object_detection/tests/common/test_case.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-import logging
 import json
 import os
-from subprocess import run
 import unittest
 
 import torch

--- a/pytorch_toolkit/object_detection/tests/run_export_tests.py
+++ b/pytorch_toolkit/object_detection/tests/run_export_tests.py
@@ -14,16 +14,26 @@
 
 """ This module contains unit tests. """
 
+import argparse
 import os
 import sys
 import unittest
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pattern', default='export_tests_*.py')
+
+    return parser.parse_args()
 
 
 def main():
     if os.path.abspath(os.getcwd()) == os.path.abspath(os.path.join(os.path.dirname(__file__), '..')):
         return 0
 
-    testsuite = unittest.TestLoader().discover(os.path.dirname(__file__), pattern='export_tests_*.py')
+    args = parse_args()
+
+    testsuite = unittest.TestLoader().discover(os.path.dirname(__file__), pattern=args.pattern)
     ret = not unittest.TextTestRunner(verbosity=1).run(testsuite).wasSuccessful()
     sys.exit(ret)
 

--- a/pytorch_toolkit/object_detection/tests/run_train_tests.py
+++ b/pytorch_toolkit/object_detection/tests/run_train_tests.py
@@ -14,16 +14,26 @@
 
 """ This module contains unit tests. """
 
+import argparse
 import os
 import sys
 import unittest
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pattern', default='train_tests_*.py')
+
+    return parser.parse_args()
 
 
 def main():
     if os.path.abspath(os.getcwd()) == os.path.abspath(os.path.join(os.path.dirname(__file__), '..')):
         return 0
 
-    testsuite = unittest.TestLoader().discover(os.path.dirname(__file__), pattern='train_tests_*.py')
+    args = parse_args()
+
+    testsuite = unittest.TestLoader().discover(os.path.dirname(__file__), pattern=args.pattern)
     ret = not unittest.TextTestRunner(verbosity=1).run(testsuite).wasSuccessful()
     sys.exit(ret)
 

--- a/pytorch_toolkit/ote/ote/misc.py
+++ b/pytorch_toolkit/ote/ote/misc.py
@@ -120,22 +120,19 @@ def get_work_dir(cfg, update_config):
 
 
 def download_snapshot_if_not_yet(template_file, output_folder):
-
     with open(template_file) as read_file:
         content = yaml.load(read_file, yaml.SafeLoader)
 
     for dependency in content['dependencies']:
-        source = dependency['source']
         destination = dependency['destination']
         if destination == 'snapshot.pth':
-
+            source = dependency['source']
             expected_size = dependency['size']
             expected_sha256 = dependency['sha256']
             if os.path.exists(os.path.join(output_folder, destination)):
                 actual = get_file_size_and_sha256(os.path.join(output_folder, destination))
                 if expected_size == actual['size'] and expected_sha256 == actual['sha256']:
                     logging.info(f'{source} has been already downloaded.')
-                    exit(-1)
                     return
 
             logging.info(f'Downloading {source}')

--- a/pytorch_toolkit/ote/ote/misc.py
+++ b/pytorch_toolkit/ote/ote/misc.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -8,6 +9,7 @@ import time
 from queue import Queue, Empty
 from threading import Thread
 
+import yaml
 from ote import MMDETECTION_TOOLS
 
 
@@ -115,3 +117,33 @@ def run_with_termination(cmd):
 def get_work_dir(cfg, update_config):
     overridden_work_dir = update_config.get('work_dir', None)
     return overridden_work_dir[0][1] if overridden_work_dir else cfg.work_dir
+
+
+def download_snapshot_if_not_yet(template_file, output_folder):
+
+    with open(template_file) as read_file:
+        content = yaml.load(read_file, yaml.SafeLoader)
+
+    for dependency in content['dependencies']:
+        source = dependency['source']
+        destination = dependency['destination']
+        if destination == 'snapshot.pth':
+
+            expected_size = dependency['size']
+            expected_sha256 = dependency['sha256']
+            if os.path.exists(os.path.join(output_folder, destination)):
+                actual = get_file_size_and_sha256(os.path.join(output_folder, destination))
+                if expected_size == actual['size'] and expected_sha256 == actual['sha256']:
+                    logging.info(f'{source} has been already downloaded.')
+                    exit(-1)
+                    return
+
+            logging.info(f'Downloading {source}')
+            subprocess.run(f'wget -q -O {os.path.join(output_folder, destination)} {source}', check=True, shell=True)
+            logging.info(f'Downloading {source} has been completed.')
+            actual = get_file_size_and_sha256(os.path.join(output_folder, destination))
+            assert expected_size == actual['size'], f'{template_file} actual_size {actual["size"]}'
+            assert expected_sha256 == actual['sha256'], f'{template_file} actual_sha256 {actual["sha256"]}'
+            return
+
+    raise RuntimeError('Failed to find snapshot.pth')

--- a/pytorch_toolkit/tests/run_model_templates_tests.py
+++ b/pytorch_toolkit/tests/run_model_templates_tests.py
@@ -87,7 +87,7 @@ class ModelTemplatesTestCase(unittest.TestCase):
                     f'. {venv_activate_path};'
                     f'export MODEL_TEMPLATES={self.work_dir};'
                     f'python3 {os.path.join(domain_folder, "tests", "run_export_tests.py")}'
-                    f' --pattern=train_tests_{problem_folder}.py',
+                    f' --pattern=export_tests_{problem_folder}.py',
                     shell=True,
                     check=True,
                     executable="/bin/bash").returncode

--- a/pytorch_toolkit/tests/run_model_templates_tests.py
+++ b/pytorch_toolkit/tests/run_model_templates_tests.py
@@ -1,19 +1,33 @@
 import glob
+import logging
 import os
 from subprocess import run
-import sys
 import tempfile
 import unittest
 
 import yaml
+
+ENABLE_TESTS_FOR = {
+    'object_detection': [
+        'face_detection',
+        'person_detection',
+        'person_vehicle_bike_detection',
+        'text_detection',
+        'vehicle_detection',
+    ],
+}
+
+ENABLE_TRAIN_TESTS = True
+ENABLE_EXPORT_TESTS = True
 
 
 class ModelTemplatesTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        logging.basicConfig(level=logging.INFO)
         cls.work_dir = tempfile.mkdtemp()
-        run(f'python3 tools/instantiate.py {cls.work_dir}', shell=True, check=True)
+        run(f'python3 tools/instantiate.py --do-not-load-snapshots {cls.work_dir}', shell=True, check=True)
 
     def test_existence_of_mandatory_files_in_template_dir(self):
         template_files = glob.glob(f'{self.work_dir}/**/template.yaml', recursive=True)
@@ -24,9 +38,11 @@ class ModelTemplatesTestCase(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(template_dirname, 'export.py')))
             self.assertTrue(os.path.exists(os.path.join(template_dirname, 'quantize.py')))
             self.assertTrue(os.path.exists(os.path.join(template_dirname, 'requirements.txt')))
-            self.assertTrue(os.path.exists(os.path.join(template_dirname, 'snapshot.pth')))
 
     def test_train_and_eval(self):
+        if not ENABLE_TRAIN_TESTS:
+            return
+
         template_files = glob.glob(f'{self.work_dir}/**/template.yaml', recursive=True)
         domain_folders = set()
         for template_file in template_files:
@@ -35,16 +51,25 @@ class ModelTemplatesTestCase(unittest.TestCase):
                 domain_folders.add(domain_folder)
 
         for domain_folder in domain_folders:
+            if domain_folder not in ENABLE_TESTS_FOR:
+                continue
             venv_activate_path = os.path.join(self.work_dir, domain_folder, 'venv', 'bin', 'activate')
-            returncode = run(
-                f'. {venv_activate_path};'
-                f'export MODEL_TEMPLATES={self.work_dir};'
-                f'python3 {os.path.join(domain_folder, "tests", "run_train_tests.py")}',
-                shell=True,
-                executable="/bin/bash").returncode
-            self.assertEqual(returncode, 0)
+            for problem_folder in ENABLE_TESTS_FOR[domain_folder]:
+                logging.info(f'Running tests for {domain_folder}/{problem_folder}.')
+                returncode = run(
+                    f'. {venv_activate_path};'
+                    f'export MODEL_TEMPLATES={self.work_dir};'
+                    f'python3 {os.path.join(domain_folder, "tests", "run_train_tests.py")}'
+                    f' --pattern=train_tests_{problem_folder}.py',
+                    shell=True,
+                    check=True,
+                    executable="/bin/bash").returncode
+                self.assertEqual(returncode, 0)
 
     def test_export(self):
+        if not ENABLE_EXPORT_TESTS:
+            return
+
         template_files = glob.glob(f'{self.work_dir}/**/template.yaml', recursive=True)
         domain_folders = set()
         for template_file in template_files:
@@ -53,14 +78,20 @@ class ModelTemplatesTestCase(unittest.TestCase):
                 domain_folders.add(domain_folder)
 
         for domain_folder in domain_folders:
+            if domain_folder not in ENABLE_TESTS_FOR:
+                continue
             venv_activate_path = os.path.join(self.work_dir, domain_folder, 'venv', 'bin', 'activate')
-            returncode = run(
-                f'. {venv_activate_path};'
-                f'export MODEL_TEMPLATES={self.work_dir};'
-                f'python3 {os.path.join(domain_folder, "tests", "run_export_tests.py")}',
-                shell=True,
-                executable="/bin/bash").returncode
-            self.assertEqual(returncode, 0)
+            for problem_folder in ENABLE_TESTS_FOR[domain_folder]:
+                logging.info(f'Running export tests for {domain_folder}/{problem_folder}.')
+                returncode = run(
+                    f'. {venv_activate_path};'
+                    f'export MODEL_TEMPLATES={self.work_dir};'
+                    f'python3 {os.path.join(domain_folder, "tests", "run_export_tests.py")}'
+                    f' --pattern=train_tests_{problem_folder}.py',
+                    shell=True,
+                    check=True,
+                    executable="/bin/bash").returncode
+                self.assertEqual(returncode, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows filtering tests by modifying `ENABLE_TESTS_FOR`, `ENABLE_TRAIN_TESTS` and `ENABLE_EXPORT_TESTS` in `pytorch_toolkit/tests/run_model_templates_tests.py` for faster debugging.