### PR TITLE
Fix bug with not-overwritten folders during instantiating template

### DIFF
--- a/pytorch_toolkit/tools/instantiate_template.py
+++ b/pytorch_toolkit/tools/instantiate_template.py
@@ -52,7 +52,7 @@ def main():
         if destination != 'snapshot.pth':
             rel_source = os.path.join(os.path.dirname(args.template), source)
             os.makedirs(os.path.dirname(os.path.join(args.output, destination)), exist_ok=True)
-            run_through_shell(f'cp -r {rel_source} {os.path.join(args.output, destination)}', check=True,
+            run_through_shell(f'cp -rT {rel_source} {os.path.join(args.output, destination)}', check=True,
                               verbose=args.verbose)
 
     if not args.do_not_load_snapshot:


### PR DESCRIPTION
Since the tool 'cp' was called without the option '-T', there was a bug
when instantiation was done onto a folder where instantiation had been
done earlier: the folder 'ote' was copied into the subfolder
'packages/ote/ote' instead of the folder 'packages/ote' itself.

This change fixes this issue.