### PR TITLE
Fix bug with not-overwritten folders during instantiating template

### DIFF
--- a/pytorch_toolkit/ote/ote/tests/test_case.py
+++ b/pytorch_toolkit/ote/ote/tests/test_case.py
@@ -348,7 +348,7 @@ def create_nncf_test_case(domain_name, problem_name, model_name, ann_file, img_r
                 logging.warning(f'ATTENTION: the folder that should be created for this test case exists!')
                 logging.warning(f'           It may cause side effects between tests!')
                 logging.warning(f'The folder is `{template_folder}`.\n')
-            run_through_shell(f'cp -a "{src_template_folder}" "{template_folder}"')
+            run_through_shell(f'cp -a --no-target-directory "{src_template_folder}" "{template_folder}"')
             assert os.path.isdir(template_folder), f'Cannot create {template_folder}'
 
         @staticmethod

--- a/pytorch_toolkit/tools/instantiate_template.py
+++ b/pytorch_toolkit/tools/instantiate_template.py
@@ -40,7 +40,7 @@ def main():
         content = yaml.load(read_file, yaml.SafeLoader)
 
     os.makedirs(args.output, exist_ok=True)
-    run_through_shell(f'cp -r {os.path.dirname(args.template)}/* {args.output}',
+    run_through_shell(f'cp -r {os.path.dirname(args.template)}/* --target-directory={args.output}',
                       verbose=args.verbose)
 
     for dependency in content['dependencies']:
@@ -48,8 +48,9 @@ def main():
         destination = dependency['destination']
         if destination != 'snapshot.pth':
             rel_source = os.path.join(os.path.dirname(args.template), source)
-            os.makedirs(os.path.dirname(os.path.join(args.output, destination)), exist_ok=True)
-            run_through_shell(f'cp -r {rel_source} {os.path.join(args.output, destination)}', check=True,
+            cur_dst = os.path.join(args.output, destination)
+            os.makedirs(os.path.dirname(cur_dst), exist_ok=True)
+            run_through_shell(f'cp -r --no-target-directory {rel_source} {cur_dst}', check=True,
                               verbose=args.verbose)
 
     if not args.do_not_load_snapshot:


### PR DESCRIPTION
Since the tool 'cp' was called without the option '--no-target-directory',
there was a bug when instantiation was done onto a folder where
instantiation had been done earlier: the folder 'ote' was copied into
the subfolder 'packages/ote/ote' instead of the folder 'packages/ote'
itself.

This change fixes this issue.