### PR TITLE
Fix transformations and accuracy in text recognition

### DIFF
--- a/misc/pytorch_toolkit/text_recognition/text_recognition/data/utils.py
+++ b/misc/pytorch_toolkit/text_recognition/text_recognition/data/utils.py
@@ -446,11 +446,10 @@ def collate_fn(sign2id, batch, *, batch_transform=None, use_ctc=False):
     # to get correct size of the tensor in the texts2tensor function
     batch.sort(key=lambda img_text: len(img_text['text'].split()), reverse=True)
 
-    imgs = [item['img'] for item in batch]
     if batch_transform:
-        imgs = batch_transform(imgs)
-    for i, item in enumerate(batch):
-        item['img'] = imgs[i]
+        imgs = batch_transform([item['img'] for item in batch])
+        for i, item in enumerate(batch):
+            item['img'] = imgs[i]
 
     # filter the pictures that have different width or height
     size = batch[0]['img'].shape

--- a/misc/pytorch_toolkit/text_recognition/text_recognition/utils/trainer.py
+++ b/misc/pytorch_toolkit/text_recognition/text_recognition/utils/trainer.py
@@ -101,7 +101,7 @@ def calculate_loss(logits, targets, target_lengths, should_cut_by_min=False, ctc
         predictions = ctc_greedy_search(logits.detach(), ctc_loss.blank)
         accuracy = 0
         for i in range(b_size):
-            gt = torch.IntTensor([c for c in targets[i] if c not in (PAD_TOKEN, END_TOKEN)])
+            gt = targets[i][:target_lengths[i]].cpu()
             if len(predictions[i]) == len(gt) and torch.all(predictions[i].eq(gt)):
                 accuracy += 1
         accuracy /= b_size

--- a/misc/pytorch_toolkit/text_recognition/text_recognition/utils/trainer.py
+++ b/misc/pytorch_toolkit/text_recognition/text_recognition/utils/trainer.py
@@ -47,7 +47,7 @@ import torch.nn
 import torch.optim as optim
 from text_recognition.data.utils import (collate_fn, create_list_of_transforms,
                                          ctc_greedy_search, get_timestamp)
-from text_recognition.data.vocab import END_TOKEN, PAD_TOKEN, read_vocab
+from text_recognition.data.vocab import PAD_TOKEN, read_vocab
 from text_recognition.datasets.dataset import BatchRandomSampler, str_to_class
 from text_recognition.models.model import TextRecognitionModel
 from torch.nn.utils import clip_grad_norm_
@@ -145,6 +145,7 @@ class Trainer:
             'CTCLossZeroInf', False)) if self.loss_type == 'CTC' else None
         self.out_size = len(self.vocab) + 1 if self.loss_type == 'CTC' else len(self.vocab)
         self.model = TextRecognitionModel(config.get('backbone_config'), self.out_size, config.get('head', {}))
+        print(self.model)
         if self.model_path is not None:
             self.model.load_weights(self.model_path, map_location=self.device)
         self.model = self.model.to(self.device)


### PR DESCRIPTION
A small fix for text recognition. 
1. Fixes a bug when resize transform was applied after filtering images of different size in batch and therefore images were dropped from batch even when resized to fixed shape.
2. Fixes a small bug in training script which lead to wrong accuracy calculation during training.