### PR TITLE
Anomaly: configurable parameter classes

### DIFF
--- a/external/anomaly/anomaly_classification/configs/__init__.py
+++ b/external/anomaly/anomaly_classification/configs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -31,7 +31,7 @@ from ote_sdk.configuration.model_lifecycle import ModelLifecycle
 
 
 @attrs
-class AnomalyClassificationConfig(ConfigurableParameters):
+class BaseAnomalyClassificationConfig(ConfigurableParameters):
     """
     Base OTE configurable parameters for anomaly classification task.
     """

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -1,3 +1,6 @@
+"""
+Configurable parameters for anomaly classification task
+"""
 # Copyright (C) 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -17,14 +17,16 @@ Configurable parameters for anomaly classification task
 
 from sys import maxsize
 
-from anomaly_classification.configs.configuration_enums import \
-    POTQuantizationPreset
+from anomaly_classification.configs.configuration_enums import POTQuantizationPreset
 from attr import attrs
 from ote_sdk.configuration import ConfigurableParameters
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group,
-                                            configurable_integer, selectable,
-                                            string_attribute)
+from ote_sdk.configuration.elements import (
+    ParameterGroup,
+    add_parameter_group,
+    configurable_integer,
+    selectable,
+    string_attribute,
+)
 from ote_sdk.configuration.model_lifecycle import ModelLifecycle
 
 

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from sys import maxsize
+
+from attr import attrs
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group,
+                                            configurable_integer,
+                                            selectable,
+                                            string_attribute)
+from ote_sdk.configuration.model_lifecycle import ModelLifecycle
+
+from anomaly_classification.configs.configuration_enums import POTQuantizationPreset
+
+
+@attrs
+class AnomalyClassificationConfig(ConfigurableParameters):
+    """
+    Base OTE configurable parameters for anomaly classification task.
+    """
+    header = string_attribute("Configuration for an anomaly classification task")
+    description = header
+
+    @attrs
+    class DatasetParameters(ParameterGroup):
+        header = string_attribute("Dataset Parameters")
+        description = header
+
+        train_batch_size = configurable_integer(
+            default_value=5,
+            min_value=1,
+            max_value=512,
+            header="Batch size",
+            description="The number of training samples seen in each iteration of training. Increasing this value "
+            "improves training time and may make the training more stable. A larger batch size has higher "
+            "memory requirements.",
+            warning="Increasing this value may cause the system to use more memory than available, "
+            "potentially causing out of memory errors, please update with caution.",
+            affects_outcome_of=ModelLifecycle.TRAINING
+        )
+
+        num_workers = configurable_integer(
+            default_value=8,
+            min_value=0,
+            max_value=8,
+            header="Number of workers",
+            description="Increasing this value might improve training speed however it might cause out of memory "
+                        "errors. If the number of workers is set to zero, data loading will happen in the main "
+                        "training thread.",
+        )
+
+    @attrs
+    class POTParameters(ParameterGroup):
+        header = string_attribute("POT Parameters")
+        description = header
+
+        preset = selectable(
+            default_value=POTQuantizationPreset.PERFORMANCE,
+            header="Preset",
+            description="Quantization preset that defines quantization scheme"
+        )
+
+        stat_subset_size = configurable_integer(
+            header="Number of data samples",
+            description="Number of data samples used for post-training optimization",
+            default_value=300,
+            min_value=1,
+            max_value=maxsize
+        )
+
+    dataset = add_parameter_group(DatasetParameters)
+    pot_parameters = add_parameter_group(POTParameters)

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -40,7 +40,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
         description = header
 
         train_batch_size = configurable_integer(
-            default_value=5,
+            default_value=32,
             min_value=1,
             max_value=512,
             header="Batch size",
@@ -55,7 +55,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
         num_workers = configurable_integer(
             default_value=8,
             min_value=0,
-            max_value=8,
+            max_value=36,
             header="Number of workers",
             description="Increasing this value might improve training speed however it might cause out of memory "
             "errors. If the number of workers is set to zero, data loading will happen in the main "

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -16,11 +16,13 @@ from sys import maxsize
 
 from attr import attrs
 from ote_sdk.configuration import ConfigurableParameters
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group,
-                                            configurable_integer,
-                                            selectable,
-                                            string_attribute)
+from ote_sdk.configuration.elements import (
+    ParameterGroup,
+    add_parameter_group,
+    configurable_integer,
+    selectable,
+    string_attribute,
+)
 from ote_sdk.configuration.model_lifecycle import ModelLifecycle
 
 from anomaly_classification.configs.configuration_enums import POTQuantizationPreset
@@ -31,6 +33,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
     """
     Base OTE configurable parameters for anomaly classification task.
     """
+
     header = string_attribute("Configuration for an anomaly classification task")
     description = header
 
@@ -49,7 +52,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
             "memory requirements.",
             warning="Increasing this value may cause the system to use more memory than available, "
             "potentially causing out of memory errors, please update with caution.",
-            affects_outcome_of=ModelLifecycle.TRAINING
+            affects_outcome_of=ModelLifecycle.TRAINING,
         )
 
         num_workers = configurable_integer(
@@ -58,8 +61,8 @@ class AnomalyClassificationConfig(ConfigurableParameters):
             max_value=8,
             header="Number of workers",
             description="Increasing this value might improve training speed however it might cause out of memory "
-                        "errors. If the number of workers is set to zero, data loading will happen in the main "
-                        "training thread.",
+            "errors. If the number of workers is set to zero, data loading will happen in the main "
+            "training thread.",
         )
 
     @attrs
@@ -70,7 +73,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
         preset = selectable(
             default_value=POTQuantizationPreset.PERFORMANCE,
             header="Preset",
-            description="Quantization preset that defines quantization scheme"
+            description="Quantization preset that defines quantization scheme",
         )
 
         stat_subset_size = configurable_integer(
@@ -78,7 +81,7 @@ class AnomalyClassificationConfig(ConfigurableParameters):
             description="Number of data samples used for post-training optimization",
             default_value=300,
             min_value=1,
-            max_value=maxsize
+            max_value=maxsize,
         )
 
     dataset = add_parameter_group(DatasetParameters)

--- a/external/anomaly/anomaly_classification/configs/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/configuration.py
@@ -14,18 +14,15 @@
 
 from sys import maxsize
 
+from anomaly_classification.configs.configuration_enums import \
+    POTQuantizationPreset
 from attr import attrs
 from ote_sdk.configuration import ConfigurableParameters
-from ote_sdk.configuration.elements import (
-    ParameterGroup,
-    add_parameter_group,
-    configurable_integer,
-    selectable,
-    string_attribute,
-)
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group,
+                                            configurable_integer, selectable,
+                                            string_attribute)
 from ote_sdk.configuration.model_lifecycle import ModelLifecycle
-
-from anomaly_classification.configs.configuration_enums import POTQuantizationPreset
 
 
 @attrs

--- a/external/anomaly/anomaly_classification/configs/configuration_enums.py
+++ b/external/anomaly/anomaly_classification/configs/configuration_enums.py
@@ -1,3 +1,6 @@
+"""
+Enums needed to define the options of selectable parameters in the configurable parameter classes
+"""
 # Copyright (C) 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/external/anomaly/anomaly_classification/configs/configuration_enums.py
+++ b/external/anomaly/anomaly_classification/configs/configuration_enums.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from ote_sdk.configuration import ConfigurableEnum
+
+
+class POTQuantizationPreset(ConfigurableEnum):
+    """
+    This Enum represents the quantization preset for post training optimization
+    """
+    PERFORMANCE = 'Performance'
+    MIXED = 'Mixed'
+
+
+class EarlyStoppingMetrics(ConfigurableEnum):
+    """
+    This enum represents the different metrics that can be used for early stopping
+    """
+    IMAGE_ROC_AUC = "image_roc_auc"
+    IMAGE_F1 = "image-f1-score"
+
+
+class ModelName(ConfigurableEnum):
+    """
+    This enum represents the different model architectures for anomaly classification
+    """
+    STFPM = "stfpm"
+    PADIM = "padim"

--- a/external/anomaly/anomaly_classification/configs/configuration_enums.py
+++ b/external/anomaly/anomaly_classification/configs/configuration_enums.py
@@ -19,14 +19,16 @@ class POTQuantizationPreset(ConfigurableEnum):
     """
     This Enum represents the quantization preset for post training optimization
     """
-    PERFORMANCE = 'Performance'
-    MIXED = 'Mixed'
+
+    PERFORMANCE = "Performance"
+    MIXED = "Mixed"
 
 
 class EarlyStoppingMetrics(ConfigurableEnum):
     """
     This enum represents the different metrics that can be used for early stopping
     """
+
     IMAGE_ROC_AUC = "image_roc_auc"
     IMAGE_F1 = "image-f1-score"
 
@@ -35,5 +37,6 @@ class ModelName(ConfigurableEnum):
     """
     This enum represents the different model architectures for anomaly classification
     """
+
     STFPM = "stfpm"
     PADIM = "padim"

--- a/external/anomaly/anomaly_classification/configs/padim/__init__.py
+++ b/external/anomaly/anomaly_classification/configs/padim/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from .configuration import PadimConfig

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from attr import attrs
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group,
+                                            string_attribute,
+                                            selectable)
+
+from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration_enums import ModelName
+
+
+@attrs
+class PadimConfig(AnomalyClassificationConfig):
+    """
+    Configurable parameters for PADIM anomaly classification task.
+    """
+    header = string_attribute("Configuration for padim")
+    description = header
+
+    @attrs
+    class ModelParameters(ParameterGroup):
+        header = string_attribute("Model Parameters")
+        description = header
+
+        name = selectable(
+            default_value=ModelName.PADIM,
+            header="Model Name",
+            description="Name of the model that should be used for training.",
+            editable=False,
+            visible_in_ui=False
+        )
+
+    model = add_parameter_group(ModelParameters)

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -27,7 +27,7 @@ class PadimConfig(AnomalyClassificationConfig):
     """
     Configurable parameters for PADIM anomaly classification task.
     """
-    header = string_attribute("Configuration for padim")
+    header = string_attribute("Configuration for Padim")
     description = header
 
     @attrs

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -15,11 +15,9 @@ Configurable parameters for Padim anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+from anomaly_classification.configs.configuration import AnomalyClassificationConfig
 from attr import attrs
-from ote_sdk.configuration.elements import (string_attribute)
-
-from anomaly_classification.configs.configuration import \
-    AnomalyClassificationConfig
+from ote_sdk.configuration.elements import string_attribute
 
 
 @attrs

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -15,13 +15,11 @@ Configurable parameters for Padim anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+from attr import attrs
+from ote_sdk.configuration.elements import (string_attribute)
+
 from anomaly_classification.configs.configuration import \
     AnomalyClassificationConfig
-from anomaly_classification.configs.configuration_enums import ModelName
-from attr import attrs
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group, selectable,
-                                            string_attribute)
 
 
 @attrs
@@ -32,18 +30,3 @@ class PadimConfig(AnomalyClassificationConfig):
 
     header = string_attribute("Configuration for Padim")
     description = header
-
-    @attrs
-    class ModelParameters(ParameterGroup):
-        header = string_attribute("Model Parameters")
-        description = header
-
-        name = selectable(
-            default_value=ModelName.PADIM,
-            header="Model Name",
-            description="Name of the model that should be used for training.",
-            editable=False,
-            visible_in_ui=False,
-        )
-
-    model = add_parameter_group(ModelParameters)

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -15,13 +15,13 @@ Configurable parameters for Padim anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration import BaseAnomalyClassificationConfig
 from attr import attrs
 from ote_sdk.configuration.elements import string_attribute
 
 
 @attrs
-class PadimConfig(AnomalyClassificationConfig):
+class PadimConfig(BaseAnomalyClassificationConfig):
     """
     Configurable parameters for PADIM anomaly classification task.
     """

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -13,10 +13,7 @@
 # and limitations under the License.
 
 from attr import attrs
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group,
-                                            string_attribute,
-                                            selectable)
+from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, string_attribute, selectable
 
 from anomaly_classification.configs.configuration import AnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import ModelName
@@ -27,6 +24,7 @@ class PadimConfig(AnomalyClassificationConfig):
     """
     Configurable parameters for PADIM anomaly classification task.
     """
+
     header = string_attribute("Configuration for Padim")
     description = header
 
@@ -40,7 +38,7 @@ class PadimConfig(AnomalyClassificationConfig):
             header="Model Name",
             description="Name of the model that should be used for training.",
             editable=False,
-            visible_in_ui=False
+            visible_in_ui=False,
         )
 
     model = add_parameter_group(ModelParameters)

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from attr import attrs
-from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, string_attribute, selectable
-
-from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration import \
+    AnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import ModelName
+from attr import attrs
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group, selectable,
+                                            string_attribute)
 
 
 @attrs

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.py
@@ -1,3 +1,6 @@
+"""
+Configurable parameters for Padim anomaly classification task
+"""
 # Copyright (C) 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -1,40 +1,29 @@
-description: Configuration for an anomaly classification task
-header: Configuration for an anomaly classification task
-type: CONFIGURABLE_PARAMETERS
-visible_in_ui: true
-
-model:
-  description: Model Parameters
-  header: Model Parameters
-  type: PARAMETER_GROUP
-  visible_in_ui: true
-  name:
-    affects_outcome_of: TRAINING
-    default_value: padim
-    description: The name of the anomaly classification algorithm.
-    editable: True
-    header: Model Name
-    enum_name: AnomalyModel
-    options:
-      PADIM: padim
-    type: SELECTABLE
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 8
+    description: Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 8
+    min_value: 0
+    type: INTEGER
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: padim
-    visible_in_ui: True
+    value: 8
+    visible_in_ui: true
     warning: null
-
-dataset:
-  description: Dataset Parameters
-  header: Dataset Parameters
   train_batch_size:
     affects_outcome_of: TRAINING
-    default_value: 32
-    description:
-      The number of training samples seen in each iteration of training.
+    default_value: 5
+    description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -49,32 +38,37 @@ dataset:
       type: UI_RULES
     value: 5
     visible_in_ui: true
-    warning:
-      Increasing this value may cause the system to use more memory than available,
+    warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
-  num_workers:
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for Padim
+header: Configuration for Padim
+id: ''
+model:
+  description: Model Parameters
+  header: Model Parameters
+  name:
     affects_outcome_of: NONE
-    default_value: 0
-    description:
-      Increasing this value might improve training speed however it might
-      cause out of memory errors. If the number of workers is set to zero, data loading
-      will happen in the main training thread.
-    editable: true
-    header: Number of cpu threads to use during batch generation
-    max_value: 8
-    min_value: 0
-    type: INTEGER
+    default_value: padim
+    description: Name of the model that should be used for training.
+    editable: false
+    enum_name: ModelName
+    header: Model Name
+    options:
+      PADIM: padim
+      STFPM: stfpm
+    type: SELECTABLE
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: 0
-    visible_in_ui: true
+    value: padim
+    visible_in_ui: false
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
-
 pot_parameters:
   description: POT Parameters
   header: POT Parameters
@@ -82,7 +76,7 @@ pot_parameters:
     affects_outcome_of: NONE
     default_value: Performance
     description: Quantization preset that defines quantization scheme
-    editable: False
+    editable: true
     enum_name: POTQuantizationPreset
     header: Preset
     options:
@@ -95,13 +89,13 @@ pot_parameters:
       rules: []
       type: UI_RULES
     value: Performance
-    visible_in_ui: False
+    visible_in_ui: true
     warning: null
   stat_subset_size:
     affects_outcome_of: NONE
     default_value: 300
     description: Number of data samples used for post-training optimization
-    editable: True
+    editable: true
     header: Number of data samples
     max_value: 9223372036854775807
     min_value: 1
@@ -112,7 +106,9 @@ pot_parameters:
       rules: []
       type: UI_RULES
     value: 300
-    visible_in_ui: True
+    visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -75,31 +75,6 @@ dataset:
   type: PARAMETER_GROUP
   visible_in_ui: true
 
-trainer:
-  description: Parameters for the PyTorch Lightning Trainer
-  header: Trainer Parameters
-  type: PARAMETER_GROUP
-  visible_in_ui: false
-  num_sanity_val_steps:
-    affects_outcome_of: NONE
-    default_value: -1
-    description:
-      This is needed to ensure that the pytorch lightning trainer starts a
-      validation run on the full validation set before training.
-    editable: false
-    header: Number of validation steps in the sanity check
-    max_value: -1
-    min_value: -1
-    type: INTEGER
-    ui_rules:
-      action: DISABLE_EDITING
-      operator: AND
-      rules: []
-      type: UI_RULES
-    value: -1
-    visible_in_ui: false
-    warning: null
-
 pot_parameters:
   description: POT Parameters
   header: POT Parameters

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -45,30 +45,6 @@ dataset:
 description: Configuration for Padim
 header: Configuration for Padim
 id: ''
-model:
-  description: Model Parameters
-  header: Model Parameters
-  name:
-    affects_outcome_of: NONE
-    default_value: padim
-    description: Name of the model that should be used for training.
-    editable: false
-    enum_name: ModelName
-    header: Model Name
-    options:
-      PADIM: padim
-      STFPM: stfpm
-    type: SELECTABLE
-    ui_rules:
-      action: DISABLE_EDITING
-      operator: AND
-      rules: []
-      type: UI_RULES
-    value: padim
-    visible_in_ui: false
-    warning: null
-  type: PARAMETER_GROUP
-  visible_in_ui: true
 pot_parameters:
   description: POT Parameters
   header: POT Parameters

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -9,7 +9,7 @@ dataset:
       will happen in the main training thread.
     editable: true
     header: Number of workers
-    max_value: 8
+    max_value: 36
     min_value: 0
     type: INTEGER
     ui_rules:
@@ -22,7 +22,7 @@ dataset:
     warning: null
   train_batch_size:
     affects_outcome_of: TRAINING
-    default_value: 5
+    default_value: 32
     description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
@@ -36,7 +36,7 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 5
+    value: 32
     visible_in_ui: true
     warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.

--- a/external/anomaly/anomaly_classification/configs/stfpm/__init__.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from .configuration import STFPMConfig

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from attr import attrs
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group,
+                                            selectable,
+                                            string_attribute)
+
+from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics, ModelName
+
+
+@attrs
+class STFPMConfig(AnomalyClassificationConfig):
+    """
+    Configurable parameters for STFPM anomaly classification task.
+    """
+    header = string_attribute("Configuration for STFPM")
+    description = header
+
+    @attrs
+    class ModelParameters(ParameterGroup):
+        header = string_attribute("Model Parameters")
+        description = header
+
+        name = selectable(
+            default_value=ModelName.STFPM,
+            header="Model Name",
+            description="Name of the model that should be used for training.",
+            editable=False,
+            visible_in_ui=False
+        )
+
+        @attrs
+        class EarlyStoppingParameters(ParameterGroup):
+            header = string_attribute("Early Stopping Parameters")
+            description = header
+
+            metric = selectable(
+                default_value=EarlyStoppingMetrics.IMAGE_ROC_AUC,
+                header="Early Stopping Metric",
+                description="The metric used to determine if the model should stop training",
+            )
+
+        early_stopping = add_parameter_group(EarlyStoppingParameters)
+
+    model = add_parameter_group(ModelParameters)

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+from anomaly_classification.configs.configuration import \
+    AnomalyClassificationConfig
+from anomaly_classification.configs.configuration_enums import (
+    EarlyStoppingMetrics, ModelName)
 from attr import attrs
-from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, selectable, string_attribute
-
-from anomaly_classification.configs.configuration import AnomalyClassificationConfig
-from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics, ModelName
+from ote_sdk.configuration.elements import (ParameterGroup,
+                                            add_parameter_group, selectable,
+                                            string_attribute)
 
 
 @attrs

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -15,14 +15,14 @@ Configurable parameters for STFPM anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from anomaly_classification.configs.configuration import \
-    AnomalyClassificationConfig
-from anomaly_classification.configs.configuration_enums import (
-    EarlyStoppingMetrics, ModelName)
 from attr import attrs
 from ote_sdk.configuration.elements import (ParameterGroup,
                                             add_parameter_group, selectable,
                                             string_attribute)
+
+from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration_enums import (
+    EarlyStoppingMetrics)
 
 
 @attrs
@@ -38,14 +38,6 @@ class STFPMConfig(AnomalyClassificationConfig):
     class ModelParameters(ParameterGroup):
         header = string_attribute("Model Parameters")
         description = header
-
-        name = selectable(
-            default_value=ModelName.STFPM,
-            header="Model Name",
-            description="Name of the model that should be used for training.",
-            editable=False,
-            visible_in_ui=False,
-        )
 
         @attrs
         class EarlyStoppingParameters(ParameterGroup):

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -1,3 +1,6 @@
+"""
+Configurable parameters for STFPM anomaly classification task
+"""
 # Copyright (C) 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -15,14 +15,10 @@ Configurable parameters for STFPM anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from attr import attrs
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group, selectable,
-                                            string_attribute)
-
 from anomaly_classification.configs.configuration import AnomalyClassificationConfig
-from anomaly_classification.configs.configuration_enums import (
-    EarlyStoppingMetrics)
+from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics
+from attr import attrs
+from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, selectable, string_attribute
 
 
 @attrs

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -15,14 +15,14 @@ Configurable parameters for STFPM anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from anomaly_classification.configs.configuration import AnomalyClassificationConfig
+from anomaly_classification.configs.configuration import BaseAnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics
 from attr import attrs
 from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, selectable, string_attribute
 
 
 @attrs
-class STFPMConfig(AnomalyClassificationConfig):
+class STFPMConfig(BaseAnomalyClassificationConfig):
     """
     Configurable parameters for STFPM anomaly classification task.
     """

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -13,10 +13,7 @@
 # and limitations under the License.
 
 from attr import attrs
-from ote_sdk.configuration.elements import (ParameterGroup,
-                                            add_parameter_group,
-                                            selectable,
-                                            string_attribute)
+from ote_sdk.configuration.elements import ParameterGroup, add_parameter_group, selectable, string_attribute
 
 from anomaly_classification.configs.configuration import AnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics, ModelName
@@ -27,6 +24,7 @@ class STFPMConfig(AnomalyClassificationConfig):
     """
     Configurable parameters for STFPM anomaly classification task.
     """
+
     header = string_attribute("Configuration for STFPM")
     description = header
 
@@ -40,7 +38,7 @@ class STFPMConfig(AnomalyClassificationConfig):
             header="Model Name",
             description="Name of the model that should be used for training.",
             editable=False,
-            visible_in_ui=False
+            visible_in_ui=False,
         )
 
         @attrs

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -72,25 +72,6 @@ model:
     type: PARAMETER_GROUP
     visible_in_ui: true
   header: Model Parameters
-  name:
-    affects_outcome_of: NONE
-    default_value: stfpm
-    description: Name of the model that should be used for training.
-    editable: false
-    enum_name: ModelName
-    header: Model Name
-    options:
-      PADIM: padim
-      STFPM: stfpm
-    type: SELECTABLE
-    ui_rules:
-      action: DISABLE_EDITING
-      operator: AND
-      rules: []
-      type: UI_RULES
-    value: stfpm
-    visible_in_ui: false
-    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 pot_parameters:

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -99,31 +99,6 @@ dataset:
   type: PARAMETER_GROUP
   visible_in_ui: true
 
-trainer:
-  description: Parameters for the PyTorch Lightning Trainer
-  header: Trainer Parameters
-  type: PARAMETER_GROUP
-  visible_in_ui: false
-  num_sanity_val_steps:
-    affects_outcome_of: NONE
-    default_value: -1
-    description:
-      This is needed to ensure that the pytorch lightning trainer starts a
-      validation run on the full validation set before training.
-    editable: false
-    header: Number of validation steps in the sanity check
-    max_value: -1
-    min_value: -1
-    type: INTEGER
-    ui_rules:
-      action: DISABLE_EDITING
-      operator: AND
-      rules: []
-      type: UI_RULES
-    value: -1
-    visible_in_ui: false
-    warning: null
-
 pot_parameters:
   description: POT Parameters
   header: POT Parameters

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -1,64 +1,29 @@
-description: Configuration for an anomaly classification task
-header: Configuration for an anomaly classification task
-type: CONFIGURABLE_PARAMETERS
-visible_in_ui: true
-
-model:
-  description: Model Parameters
-  header: Model Parameters
-  type: PARAMETER_GROUP
-  visible_in_ui: true
-  name:
-    affects_outcome_of: TRAINING
-    default_value: stfpm
-    description: The name of the anomaly classification algorithm.
-    editable: True
-    header: Model Name
-    enum_name: AnomalyModel
-    options:
-      STFPM: stfpm
-    type: SELECTABLE
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 8
+    description: Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 8
+    min_value: 0
+    type: INTEGER
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: stfpm
-    visible_in_ui: True
-    warning: null
-  early_stopping:
-    description: Terminate the training when the performance converges.
-    header: Early Stopping Parameters
-    type: PARAMETER_GROUP
+    value: 8
     visible_in_ui: true
-    metric:
-      affects_outcome_of: TRAINING
-      default_value: image_roc_auc
-      description: The metric used for early stopping.
-      editable: True
-      header: Early Stopping Metric
-      enum_name: EarlyStoppingMetric
-      options:
-        PIXEL_ROC_AUC: pixel_roc_auc
-        IMAGE_ROC_AUC: image_roc_auc
-      type: SELECTABLE
-      ui_rules:
-        action: DISABLE_EDITING
-        operator: AND
-        rules: []
-        type: UI_RULES
-      value: image_roc_auc
-      visible_in_ui: True
-      warning: null
-
-dataset:
-  description: Dataset Parameters
-  header: Dataset Parameters
+    warning: null
   train_batch_size:
     affects_outcome_of: TRAINING
-    default_value: 32
-    description:
-      The number of training samples seen in each iteration of training.
+    default_value: 5
+    description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -73,32 +38,61 @@ dataset:
       type: UI_RULES
     value: 5
     visible_in_ui: true
-    warning:
-      Increasing this value may cause the system to use more memory than available,
+    warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
-  num_workers:
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for STFPM
+header: Configuration for STFPM
+id: ''
+model:
+  description: Model Parameters
+  early_stopping:
+    description: Early Stopping Parameters
+    header: Early Stopping Parameters
+    metric:
+      affects_outcome_of: NONE
+      default_value: image_roc_auc
+      description: The metric used to determine if the model should stop training
+      editable: true
+      enum_name: EarlyStoppingMetrics
+      header: Early Stopping Metric
+      options:
+        IMAGE_F1: image-f1-score
+        IMAGE_ROC_AUC: image_roc_auc
+      type: SELECTABLE
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: image_roc_auc
+      visible_in_ui: true
+      warning: null
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+  header: Model Parameters
+  name:
     affects_outcome_of: NONE
-    default_value: 0
-    description:
-      Increasing this value might improve training speed however it might
-      cause out of memory errors. If the number of workers is set to zero, data loading
-      will happen in the main training thread.
-    editable: true
-    header: Number of cpu threads to use during batch generation
-    max_value: 8
-    min_value: 0
-    type: INTEGER
+    default_value: stfpm
+    description: Name of the model that should be used for training.
+    editable: false
+    enum_name: ModelName
+    header: Model Name
+    options:
+      PADIM: padim
+      STFPM: stfpm
+    type: SELECTABLE
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: 0
-    visible_in_ui: true
+    value: stfpm
+    visible_in_ui: false
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
-
 pot_parameters:
   description: POT Parameters
   header: POT Parameters
@@ -106,7 +100,7 @@ pot_parameters:
     affects_outcome_of: NONE
     default_value: Performance
     description: Quantization preset that defines quantization scheme
-    editable: False
+    editable: true
     enum_name: POTQuantizationPreset
     header: Preset
     options:
@@ -119,13 +113,13 @@ pot_parameters:
       rules: []
       type: UI_RULES
     value: Performance
-    visible_in_ui: False
+    visible_in_ui: true
     warning: null
   stat_subset_size:
     affects_outcome_of: NONE
     default_value: 300
     description: Number of data samples used for post-training optimization
-    editable: True
+    editable: true
     header: Number of data samples
     max_value: 9223372036854775807
     min_value: 1
@@ -136,7 +130,9 @@ pot_parameters:
       rules: []
       type: UI_RULES
     value: 300
-    visible_in_ui: True
+    visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -9,7 +9,7 @@ dataset:
       will happen in the main training thread.
     editable: true
     header: Number of workers
-    max_value: 8
+    max_value: 36
     min_value: 0
     type: INTEGER
     ui_rules:
@@ -22,7 +22,7 @@ dataset:
     warning: null
   train_batch_size:
     affects_outcome_of: TRAINING
-    default_value: 5
+    default_value: 32
     description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
@@ -36,7 +36,7 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 5
+    value: 32
     visible_in_ui: true
     warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -43,10 +43,7 @@ from ote_sdk.entities.task_environment import TaskEnvironment
 from ote_sdk.usecases.evaluation.metrics_helper import MetricsHelper
 from ote_sdk.usecases.tasks.interfaces.evaluate_interface import IEvaluationTask
 from ote_sdk.usecases.tasks.interfaces.inference_interface import IInferenceTask
-from ote_sdk.usecases.tasks.interfaces.optimization_interface import (
-    IOptimizationTask,
-    OptimizationType,
-)
+from ote_sdk.usecases.tasks.interfaces.optimization_interface import IOptimizationTask, OptimizationType
 
 logger = logging.getLogger(__name__)
 

--- a/external/anomaly/anomaly_classification/task.py
+++ b/external/anomaly/anomaly_classification/task.py
@@ -61,13 +61,13 @@ class AnomalyClassificationTask(ITrainingTask, IInferenceTask, IEvaluationTask, 
 
     def __init__(self, task_environment: TaskEnvironment):
         self.task_environment = task_environment
+        self.model_name = task_environment.model_template.name
         self.labels = task_environment.get_labels()
 
         # Hyperparameters.
         self.project_path: str = tempfile.mkdtemp(prefix="ote-anomalib")
         self.config = self.get_config()
 
-        self.model_name = task_environment.model_template.name
         self.model = self.load_model(ote_model=task_environment.model)
 
         self.trainer: Trainer
@@ -80,7 +80,7 @@ class AnomalyClassificationTask(ITrainingTask, IInferenceTask, IEvaluationTask, 
             Union[DictConfig, ListConfig]: Anomalib config
         """
         hyper_parameters = self.task_environment.get_hyper_parameters()
-        config = get_anomalib_config(ote_config=hyper_parameters)
+        config = get_anomalib_config(task_name=self.model_name, ote_config=hyper_parameters)
         config.dataset.task = "classification"
         config.project.path = self.project_path
         return config

--- a/external/anomaly/ote_anomalib/config/config.py
+++ b/external/anomaly/ote_anomalib/config/config.py
@@ -25,8 +25,10 @@ from ote_sdk.configuration.configurable_parameters import ConfigurableParameters
 import anomalib
 from anomalib.config.config import get_configurable_parameters
 
+model_names = {"ote anomaly classification padim": "padim", "ote anomaly classification stfpm": "stfpm"}
 
-def get_anomalib_config(ote_config: ConfigurableParameters) -> Union[DictConfig, ListConfig]:
+
+def get_anomalib_config(task_name: str, ote_config: ConfigurableParameters) -> Union[DictConfig, ListConfig]:
     """
     Create an anomalib config object that matches the values specified in the OTE config.
 
@@ -35,7 +37,7 @@ def get_anomalib_config(ote_config: ConfigurableParameters) -> Union[DictConfig,
     Returns:
         Anomalib config object for the specified model type with overwritten default values.
     """
-    model_name = getattr(ote_config, "model").name.value
+    model_name = model_names[task_name]
     model_config_path = Path(anomalib.__file__).parent / "models" / model_name / "config.yaml"
     anomalib_config = get_configurable_parameters(model_name=model_name, model_config_path=model_config_path)
     update_anomalib_config(anomalib_config, ote_config)

--- a/external/anomaly/tests/helpers/config.py
+++ b/external/anomaly/tests/helpers/config.py
@@ -21,9 +21,9 @@ from ote_sdk.configuration.helper import create
 from ote_sdk.entities.model_template import ModelTemplate, parse_model_template
 
 
-def get_config(template_file_path: str):
+def get_config_and_task_name(template_file_path: str):
 
     model_template: ModelTemplate = parse_model_template(template_file_path)
     hyper_parameters: dict = model_template.hyper_parameters.data
     config: ConfigurableParameters = create(hyper_parameters)
-    return config
+    return config, model_template.name

--- a/external/anomaly/tests/helpers/dataset.py
+++ b/external/anomaly/tests/helpers/dataset.py
@@ -20,11 +20,7 @@ from pathlib import Path
 from typing import List, Union
 
 from anomalib.datasets.anomaly_dataset import make_dataset
-from ote_sdk.entities.annotation import (
-    Annotation,
-    AnnotationSceneEntity,
-    AnnotationSceneKind,
-)
+from ote_sdk.entities.annotation import Annotation, AnnotationSceneEntity, AnnotationSceneKind
 from ote_sdk.entities.dataset_item import DatasetItemEntity
 from ote_sdk.entities.datasets import DatasetEntity
 from ote_sdk.entities.image import Image

--- a/external/anomaly/tests/helpers/train.py
+++ b/external/anomaly/tests/helpers/train.py
@@ -22,20 +22,11 @@ import os
 import time
 from typing import Union
 
-from anomaly_classification import (
-    AnomalyClassificationTask,
-    OpenVINOAnomalyClassificationTask,
-)
+from anomaly_classification import AnomalyClassificationTask, OpenVINOAnomalyClassificationTask
 from ote_sdk.configuration.helper import create
 from ote_sdk.entities.inference_parameters import InferenceParameters
 from ote_sdk.entities.label_schema import LabelSchemaEntity
-from ote_sdk.entities.model import (
-    ModelEntity,
-    ModelOptimizationType,
-    ModelPrecision,
-    ModelStatus,
-    OptimizationMethod,
-)
+from ote_sdk.entities.model import ModelEntity, ModelOptimizationType, ModelPrecision, ModelStatus, OptimizationMethod
 from ote_sdk.entities.model_template import TargetDevice, parse_model_template
 from ote_sdk.entities.optimization_parameters import OptimizationParameters
 from ote_sdk.entities.resultset import ResultSetEntity
@@ -44,7 +35,6 @@ from ote_sdk.entities.task_environment import TaskEnvironment
 from ote_sdk.entities.train_parameters import TrainParameters
 from ote_sdk.usecases.tasks.interfaces.export_interface import ExportType
 from ote_sdk.usecases.tasks.interfaces.optimization_interface import OptimizationType
-
 from tests.helpers.dataset import OTEAnomalyDatasetGenerator
 
 logger = logging.getLogger(__name__)

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -29,9 +29,7 @@ from ote_anomalib.config import get_anomalib_config
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    ["configurable_parameters"], [(PadimConfig, ), (STFPMConfig, )]
-)
+@pytest.mark.parametrize(["configurable_parameters"], [(PadimConfig,), (STFPMConfig,)])
 def test_configuration_yaml(configurable_parameters):
     configuration = configurable_parameters()
     # assert that we can convert our config object to yaml format
@@ -42,5 +40,7 @@ def test_configuration_yaml(configurable_parameters):
     get_anomalib_config(configuration_yaml_converted)
     # assert that the python class and the yaml file result in the same configurable parameters object
     model_name = configuration_yaml_converted.model.name.value
-    configuration_yaml_loaded = create(os.path.join('anomaly_classification', 'configs', model_name, 'configuration.yaml'))
+    configuration_yaml_loaded = create(
+        os.path.join("anomaly_classification", "configs", model_name, "configuration.yaml")
+    )
     assert configuration_yaml_converted == configuration_yaml_loaded

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -17,6 +17,7 @@ Test configurable parameters for the anomaly classification task
 # and limitations under the License.
 
 import logging
+import os
 
 import pytest
 from ote_sdk.configuration.helper import convert, create
@@ -39,3 +40,7 @@ def test_configuration_yaml(configurable_parameters):
     configuration_yaml_converted = create(configuration_yaml_str)
     # assert that we generate an anomalib config from the
     get_anomalib_config(configuration_yaml_converted)
+    # assert that the python class and the yaml file result in the same configurable parameters object
+    model_name = configuration_yaml_converted.model.name.value
+    configuration_yaml_loaded = create(os.path.join('anomaly_classification', 'configs', model_name, 'configuration.yaml'))
+    assert configuration_yaml_converted == configuration_yaml_loaded

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -20,11 +20,10 @@ import logging
 import os
 
 import pytest
-from ote_sdk.configuration.helper import convert, create
-
 from anomaly_classification.configs.padim import PadimConfig
 from anomaly_classification.configs.stfpm import STFPMConfig
 from ote_anomalib.config import get_anomalib_config
+from ote_sdk.configuration.helper import convert, create
 
 logger = logging.getLogger(__name__)
 

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -1,0 +1,41 @@
+"""
+Test configurable parameters for the anomaly classification task
+"""
+
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import logging
+
+import pytest
+from ote_sdk.configuration.helper import convert, create
+
+from anomaly_classification.configs.padim import PadimConfig
+from anomaly_classification.configs.stfpm import STFPMConfig
+from ote_anomalib.config import get_anomalib_config
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    ["configurable_parameters"], [PadimConfig, STFPMConfig]
+)
+def test_configuration_yaml(configurable_parameters):
+    configuration = configurable_parameters()
+    # assert that we can convert our config object to yaml format
+    configuration_yaml_str = convert(configuration, str)
+    # assert that we can create a SC config object from the yaml string
+    configuration_yaml_converted = create(configuration_yaml_str)
+    # assert that we generate an anomalib config from the
+    get_anomalib_config(configuration_yaml_converted)

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize(
-    ["configurable_parameters"], [PadimConfig, STFPMConfig]
+    ["configurable_parameters"], [(PadimConfig, ), (STFPMConfig, )]
 )
 def test_configuration_yaml(configurable_parameters):
     configuration = configurable_parameters()

--- a/external/anomaly/tests/test_configurable_parameters.py
+++ b/external/anomaly/tests/test_configurable_parameters.py
@@ -20,13 +20,12 @@ import logging
 import os
 
 import pytest
-from ote_sdk.configuration.helper import convert, create
-from ote_sdk.entities.model_template import parse_model_template
-
-from tests.helpers.config import get_config_and_task_name
 from anomaly_classification.configs.padim import PadimConfig
 from anomaly_classification.configs.stfpm import STFPMConfig
 from ote_anomalib.config import get_anomalib_config
+from ote_sdk.configuration.helper import convert, create
+from ote_sdk.entities.model_template import parse_model_template
+from tests.helpers.config import get_config_and_task_name
 
 logger = logging.getLogger(__name__)
 

--- a/external/anomaly/tests/test_ote_anomaly_classification.py
+++ b/external/anomaly/tests/test_ote_anomaly_classification.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 from ote_anomalib.config import get_anomalib_config
 
-from tests.helpers.config import get_config
+from tests.helpers.config import get_config_and_task_name
 from tests.helpers.dummy_dataset import TestDataset
 from tests.helpers.train import OTEAnomalyTrainer
 
@@ -47,12 +47,12 @@ class TestAnomalyClassification:
         """
         train_batch_size = 16
 
-        ote_config = get_config(f"{task_path}/configs/{template_path}/template.yaml")
+        ote_config, task_name = get_config_and_task_name(f"{task_path}/configs/{template_path}/template.yaml")
 
         # change parameter value in OTE config
         ote_config.dataset.train_batch_size = train_batch_size
         # convert OTE -> Anomalib
-        anomalib_config = get_anomalib_config(ote_config)
+        anomalib_config = get_anomalib_config(task_name, ote_config)
         # check if default parameter was overwritten
         assert anomalib_config.dataset.train_batch_size == train_batch_size
 

--- a/external/anomaly/tests/test_ote_anomaly_classification.py
+++ b/external/anomaly/tests/test_ote_anomaly_classification.py
@@ -22,7 +22,6 @@ from threading import Thread
 import numpy as np
 import pytest
 from ote_anomalib.config import get_anomalib_config
-
 from tests.helpers.config import get_config_and_task_name
 from tests.helpers.dummy_dataset import TestDataset
 from tests.helpers.train import OTEAnomalyTrainer


### PR DESCRIPTION
This PR adds a base configurable parameters class for anomaly classification, as well as separate classes for Padim and STFPM. Also adds a test case to check if the configurable parameters can be correctly converted to yaml file. 

The old `configuration.yaml` files were overwritten by new files generated by converting the python classes.