### PR TITLE
OTE_SDK. add ModelStatus.TRAINED_NO_STATS

### DIFF
--- a/ote_sdk/ote_sdk/entities/model.py
+++ b/ote_sdk/ote_sdk/entities/model.py
@@ -68,7 +68,7 @@ class ModelStatus(IntEnum):
     """Indicates the status of the last training result"""
 
     NOT_READY = auto()  # Model is not ready to be trained
-    WEIGHTS_INITIALIZED = auto()  # Model is untrained but weights are initialized
+    TRAINED_NO_STATS = auto()  # Model is trained but not evaluated yet
     SUCCESS = auto()  # Model trained successfully and improved
     FAILED = (
         auto()


### PR DESCRIPTION
This is needed by SC, and it's the first step in the migration of `ModelStatus` from `ote_sdk` to `sc_sdk`.